### PR TITLE
Add support for dot notation when packing query

### DIFF
--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -7,9 +7,7 @@
    [com.timezynk.domain.update-leafs :refer [update-leafs]]
    [com.timezynk.useful.date :as ud]
    [com.timezynk.useful.mongo :as um :refer [object-id? intersecting-query start-inside-period-query]]
-   [slingshot.slingshot :refer [throw+]]
-  ))
-
+   [slingshot.slingshot :refer [throw+]]))
 
                                         ;pack query
 
@@ -45,6 +43,16 @@
           (let [[head & tail] trail
                 [tail-head]   tail]
             (cond
+              (and (keyword? head)
+                   (s/includes? (name head) "."))
+              (let [raw-trail (-> head
+                                  (name)
+                                  (s/split #"\."))
+                    next-trail (->> raw-trail
+                                    (r/map keyword)
+                                    (into []))]
+                (recur next-trail
+                       path))
               (= [] tail-head) (let [tail (rest tail)]
                                  (recur tail
                                         (conj path head
@@ -94,7 +102,6 @@
         (pack-query-parameters properties)
         (replace-with-mongo-operators))))
 
-
                                         ; pack collects
 
 (defn- pack-collect [properties [property-name options]]
@@ -132,7 +139,6 @@
                (fn [[k p]]
                  (get p flag))
                properties))))
-
 
                                         ; pack body
 

--- a/domain/test/com/timezynk/domain/pack_test.clj
+++ b/domain/test/com/timezynk/domain/pack_test.clj
@@ -1,0 +1,10 @@
+(ns com.timezynk.domain.pack-test
+  (:require [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
+            [com.timezynk.domain.pack :as p]))
+
+(deftest test-1
+  (testing "Should build path when path is defined as keyword with dot notation"
+    (let [trail '(:relations.outgoing-rfq-id)
+          result (p/get-type-path trail)]
+      (is (= result [:relations :properties :outgoing-rfq-id :type])))))


### PR DESCRIPTION
E.g. {:some.id "606dcc558c52495f3164f55a"} should have its value type
cast as object-id, parsing the query to {:some.id (ObjectId "606dcc558c52495f3164f55a")}