### PR TITLE
Add support for dot notation when packing query

### DIFF
--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -103,7 +103,7 @@
         (pack-query-parameters properties)
         (replace-with-mongo-operators))))
 
-                                       ; pack collects
+                                        ; pack collects
 
 
 (defn- pack-collect [properties [property-name options]]
@@ -142,7 +142,7 @@
                  (get p flag))
                properties))))
 
-                                       ; pack body
+                                         ; pack body
 
 
 (defn pack-doc

--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -9,7 +9,7 @@
    [com.timezynk.useful.mongo :as um :refer [object-id? intersecting-query start-inside-period-query]]
    [slingshot.slingshot :refer [throw+]]))
 
-                                       ;pack query
+                                        ;pack query
 
 
 (def mongo-operators {:_from_ :$gte
@@ -142,7 +142,7 @@
                  (get p flag))
                properties))))
 
-                                         ; pack body
+                                        ; pack body
 
 
 (defn pack-doc

--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -46,12 +46,12 @@
             (cond
               (and (keyword? head)
                    (s/includes? (name head) "."))
-              (let [raw-trail (-> head
-                                  (name)
-                                  (s/split #"\."))
-                    next-trail (->> raw-trail
-                                    (r/map keyword)
-                                    (into []))]
+              (let [next-trail (-> head
+                                   (name)
+                                   (s/split #"\.")
+                                   (->> (r/map keyword)
+                                        (into []))
+                                   (concat tail))]
                 (recur next-trail
                        path))
               (= [] tail-head) (let [tail (rest tail)]

--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -9,8 +9,7 @@
    [com.timezynk.useful.mongo :as um :refer [object-id? intersecting-query start-inside-period-query]]
    [slingshot.slingshot :refer [throw+]]))
 
-
-                                        ;pack query
+                                       ;pack query
 
 
 (def mongo-operators {:_from_ :$gte
@@ -45,6 +44,16 @@
           (let [[head & tail] trail
                 [tail-head]   tail]
             (cond
+              (and (keyword? head)
+                   (s/includes? (name head) "."))
+              (let [raw-trail (-> head
+                                  (name)
+                                  (s/split #"\."))
+                    next-trail (->> raw-trail
+                                    (r/map keyword)
+                                    (into []))]
+                (recur next-trail
+                       path))
               (= [] tail-head) (let [tail (rest tail)]
                                  (recur tail
                                         (conj path head
@@ -94,8 +103,7 @@
         (pack-query-parameters properties)
         (replace-with-mongo-operators))))
 
-
-                                        ; pack collects
+                                       ; pack collects
 
 
 (defn- pack-collect [properties [property-name options]]
@@ -134,8 +142,7 @@
                  (get p flag))
                properties))))
 
-
-                                        ; pack body
+                                       ; pack body
 
 
 (defn pack-doc

--- a/domain/test/com/timezynk/domain/pack_test.clj
+++ b/domain/test/com/timezynk/domain/pack_test.clj
@@ -31,19 +31,19 @@
 
 (deftest get-type-path-test
   (testing "Should build path when path is defined from nested map structure"
-    (let [trail '(:id :outgoing-rfq-id :relations :wrapper)
+    (let [trail '(:id :to :path :some)
           result (p/get-type-path trail)]
-      (is (= result [:wrapper :properties :relations :properties :outgoing-rfq-id :properties :id :type]))))
+      (is (= result [:some :properties :path :properties :to :properties :id :type]))))
 
   (testing "Should build path when path is defined as keyword with dot notation"
-    (let [trail '(:relations.outgoing-rfq-id)
+    (let [trail '(:some.path)
           result (p/get-type-path trail)]
-      (is (= result [:relations :properties :outgoing-rfq-id :type]))))
+      (is (= result [:some :properties :path :type]))))
 
   (testing "Should build path when path is defined with dot notation and has nested map"
-    (let [trail '(:id :relations.outgoing-rfq-id :wrapper)
+    (let [trail '(:id :path.to :some)
           result (p/get-type-path trail)]
-      (is (= result [:wrapper :properties :relations :properties :outgoing-rfq-id :properties :id :type])))))
+      (is (= result [:some :properties :path :properties :to :properties :id :type])))))
 
 (deftest pack-query-nested-query
   (let [dtc {:properties

--- a/domain/test/com/timezynk/domain/pack_test.clj
+++ b/domain/test/com/timezynk/domain/pack_test.clj
@@ -29,8 +29,52 @@
     (is (= {:related-id {:$gte (um/object-id "5ec25abf087fec363a7f15f2")
                          :$lte (um/object-id "5ec25ac4087fec363a7f15f3")}} q))))
 
-(deftest pack-dot-notation
+(deftest get-type-path-test
+  (testing "Should build path when path is defined from nested map structure"
+    (let [trail '(:id :outgoing-rfq-id :relations :wrapper)
+          result (p/get-type-path trail)]
+      (is (= result [:wrapper :properties :relations :properties :outgoing-rfq-id :properties :id :type]))))
+
   (testing "Should build path when path is defined as keyword with dot notation"
     (let [trail '(:relations.outgoing-rfq-id)
           result (p/get-type-path trail)]
-      (is (= result [:relations :properties :outgoing-rfq-id :type])))))
+      (is (= result [:relations :properties :outgoing-rfq-id :type]))))
+
+  (testing "Should build path when path is defined with dot notation and has nested map"
+    (let [trail '(:id :relations.outgoing-rfq-id :wrapper)
+          result (p/get-type-path trail)]
+      (is (= result [:wrapper :properties :relations :properties :outgoing-rfq-id :properties :id :type])))))
+
+(deftest pack-query-nested-query
+  (let [dtc {:properties
+             {:some
+              {:type :map
+               :properties
+               {:path
+                {:type :map
+                 :properties
+                 {:to
+                  {:type :map
+                   :properties
+                   {:id
+                    {:type :object-id}}}}}}}}}]
+
+    (testing "Should parse query with nested map structure"
+      (let [request {:domain-query-params {:some {:path {:to {:id "606c2556a14152e702448f6f"}}}
+                                           :company-id (um/object-id "5f08667cfc3107569d6deb79")}
+                     :route-params {:company-id (um/object-id "5f08667cfc3107569d6deb79")}}
+            result (p/pack-query dtc request)]
+        (is (-> result :some :path :to :id (um/object-id?)))))
+
+    (testing "Should parse query with single dot notation field"
+      (let [request {:domain-query-params {:some.path.to.id "606c2556a14152e702448f6f"
+                                           :company-id (um/object-id "5f08667cfc3107569d6deb79")}
+                     :route-params {:company-id (um/object-id "5f08667cfc3107569d6deb79")}}
+            result (p/pack-query dtc request)]
+        (is (-> result :some.path.to.id (um/object-id?)))))
+    (testing "Should parse query with nested map structure include dot notation field"
+      (let [request {:domain-query-params {:some {:path.to {:id "606c2556a14152e702448f6f"}}
+                                           :company-id (um/object-id "5f08667cfc3107569d6deb79")}
+                     :route-params {:company-id (um/object-id "5f08667cfc3107569d6deb79")}}
+            result (p/pack-query dtc request)]
+        (is (-> result :some :path.to :id (um/object-id?)))))))

--- a/domain/test/com/timezynk/domain/pack_test.clj
+++ b/domain/test/com/timezynk/domain/pack_test.clj
@@ -28,3 +28,9 @@
                                                                  :_lte_ "5ec25ac4087fec363a7f15f3"}}})]
     (is (= {:related-id {:$gte (um/object-id "5ec25abf087fec363a7f15f2")
                          :$lte (um/object-id "5ec25ac4087fec363a7f15f3")}} q))))
+
+(deftest pack-dot-notation
+  (testing "Should build path when path is defined as keyword with dot notation"
+    (let [trail '(:relations.outgoing-rfq-id)
+          result (p/get-type-path trail)]
+      (is (= result [:relations :properties :outgoing-rfq-id :type])))))


### PR DESCRIPTION
E.g. `{:some.id "606dcc558c52495f3164f55a"}` should have its value type
cast as object-id, parsing the query to `{:some.id (ObjectId "606dcc558c52495f3164f55a")}`