### PR TITLE
Feature: property mask

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.5.0"
+(defproject com.timezynk/domain "1.6.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -274,9 +274,6 @@
                  (f dom-type-collection docs))]
     (with-meta v (meta docs))))
 
-(defn get-dtc-name [dtc]
-  (or (:ability-name dtc) (:name dtc)))
-
 (defn- mask
   "Builds a station which redacts from doc those properties, which:
     * have been marked for masking
@@ -397,6 +394,9 @@
 
 (defn dom-response [doc req restriction collects]
   (etag-response req doc))
+
+(defn get-dtc-name [dtc]
+  (or (:ability-name dtc) (:name dtc)))
 
 (def ^:dynamic *request* nil)
 

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -368,7 +368,7 @@
                                         ; HTTP routes
 
 
-(defn add-stations* [line stations]
+(defn- add-stations* [line stations]
   (if (sequential? stations)
     (let [add-s (->> stations
                      (partition 3)

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -316,8 +316,8 @@
                                       validate-doc!
                                       validate-id-availability]
                        :pre-process  [add-default-values (add-derived-values false)]
-                       :execute      execute-insert!
                        :redact       (redactor :create)
+                       :execute      execute-insert!
                        :deref        deref-steps]
                       :wrapper-f wrapper-f
                       :environment))
@@ -328,8 +328,8 @@
                                       validate-properties2!
                                       validate-doc!]
                        :pre-process  (add-derived-values true)
-                       :execute      execute-update!
                        :redact       (redactor :update)
+                       :execute      execute-update!
                        :deref        deref-steps]
                       :wrapper-f wrapper-f
                       :environment))

--- a/domain/src/com/timezynk/domain/dtc/masks.clj
+++ b/domain/src/com/timezynk/domain/dtc/masks.clj
@@ -1,0 +1,13 @@
+(ns com.timezynk.domain.dtc.masks
+  "Useful functions for masking DTC properties."
+  (:require [com.timezynk.useful.cancan :as ability]
+            [com.timezynk.domain.core :as c]))
+
+(defn authorization
+  "True if doc is missing authorization to contain the incoming property."
+  [dtc doc action property-name]
+  (let [action (keyword (format "%s-property-%s"
+                                (name action)
+                                (name property-name)))
+        object (c/get-dtc-name dtc)]
+    (not (ability/can? action object doc))))

--- a/domain/src/com/timezynk/domain/mongo/core.clj
+++ b/domain/src/com/timezynk/domain/mongo/core.clj
@@ -61,7 +61,7 @@
          {:valid-from (System/currentTimeMillis)
           :valid-to   nil}))
 
-(defn- insert! [cname new]
+(defn insert! [cname new]
   (mongo/with-mongo @db
     (let [new (->> new
                    (r/map rename-ids-in)
@@ -97,7 +97,7 @@
       (mchan/put! :update cname newlings oldies)
       newlings)))
 
-(defn- update! [cname restriction new-doc]
+(defn update! [cname restriction new-doc]
   (mongo/with-mongo @db
     (let [now         (System/currentTimeMillis)
           restriction (postwalk-replace ids-in restriction)

--- a/domain/test/com/timezynk/domain/dtc/masks_test.clj
+++ b/domain/test/com/timezynk/domain/dtc/masks_test.clj
@@ -1,9 +1,8 @@
-(ns com.timezynk.domain.redaction-test
-  "Elevation of authorization barrier on a per-property basis"
+(ns com.timezynk.domain.dtc.masks-test
   (:require [clojure.test :refer [deftest is testing compose-fixtures use-fixtures]]
-[clojure.tools.logging :as log]
             [spy.core :refer [stub spy called-once? call-matching?]]
             [com.timezynk.domain.core :as c]
+            [com.timezynk.domain.dtc.masks :refer [authorization]]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.mongo.core :as m]
             [com.timezynk.useful.cancan :as ability]
@@ -15,7 +14,7 @@
 
 (def ^:const dtc-properties
   {:x (s/string)
-   :y (s/string :authorize-individually? true)
+   :y (s/string :mask authorization)
    :z (s/string)})
 
 (def ^:const records
@@ -51,7 +50,7 @@
         (testing "object"
           (is (call-matching? ability/can? (comp #{:qwerty} second))))))))
 
-(comment (deftest creating
+(deftest creating
   (testing "Adding to the store"
     @(p/conj! *dtc* {:x "cba" :y "321" :z "zyx" :company-id (ObjectId.)})
     (testing "marked property"
@@ -61,9 +60,9 @@
     (testing "unmarked property"
       (is (call-matching? m/insert! (fn [[_ new-doc]]
                                       (let [new-doc (peek (into [] new-doc))]
-                                        (contains? new-doc :z)))))))))
+                                        (contains? new-doc :z))))))))
 
-(comment (deftest updating
+(deftest updating
   (testing "Updating the store"
     @(p/update-in! *dtc* {} {:y "321" :z "zyx"})
     (testing "marked property"
@@ -71,4 +70,4 @@
                                       (not (contains? new-doc :y))))))
     (testing "unmarked property"
       (is (call-matching? m/update! (fn [[_ _ new-doc]]
-                                      (contains? new-doc :z))))))))
+                                      (contains? new-doc :z)))))))

--- a/domain/test/com/timezynk/domain/redaction_test.clj
+++ b/domain/test/com/timezynk/domain/redaction_test.clj
@@ -1,48 +1,74 @@
 (ns com.timezynk.domain.redaction-test
   "Elevation of authorization barrier on a per-property basis"
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing compose-fixtures use-fixtures]]
 [clojure.tools.logging :as log]
             [spy.core :refer [stub spy called-once? call-matching?]]
-            [com.timezynk.domain.core :refer [dom-type-collection]]
+            [com.timezynk.domain.core :as c]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.mongo.core :as m]
             [com.timezynk.useful.cancan :as ability]
-            [com.timezynk.domain.persistence :as p]))
+            [com.timezynk.domain.persistence :as p]
+            [com.timezynk.domain.utils :as u])
+  (:import [org.bson.types ObjectId]))
 
-(def dtc
-  (dom-type-collection :name :qwerty
-                       :properties {:x (s/string)
-                                    :y (s/string :authorize-individually? true)
-                                    :z (s/string)}))
+(def ^:dynamic *dtc*)
+
+(def ^:const dtc-properties
+  {:x (s/string)
+   :y (s/string :authorize-individually? true)
+   :z (s/string)})
 
 (def ^:const records
   [{:x "abc" :y "123" :z "xyz"}])
 
-(defn- with-immutable-inmemory-store [f]
-  (with-redefs [m/fetch         (stub records)
-                m/insert!       (stub {})
-                m/update-fast!  (spy (fn [_ _ doc] doc))
-                m/update!       (spy (fn [_ _ doc] doc))
-                m/destroy-fast! (stub {})
-                m/destroy!      (stub {})]
+(defn- create-dtc [f]
+  (binding [*dtc* (c/dom-type-collection :name :qwerty
+                                         :properties dtc-properties)]
     (f)))
 
-(use-fixtures :once #'with-immutable-inmemory-store)
+(defn- with-authorization-failure [f]
+  (with-redefs [ability/can? (stub false)]
+    (f)))
+
+(use-fixtures :each (->> create-dtc
+                         (compose-fixtures (u/build-immutable-inmemory-store records))
+                         (compose-fixtures with-authorization-failure)))
 
 (deftest reading
   (testing "Reading from the store"
-    (with-redefs [ability/can? (stub false)]
-      (let [result @(p/select dtc)
-            doc (first result)]
-        (testing "marked property"
-          (is (not (contains? doc :y))))
-        (testing "unmarked properties"
-          (is (contains? doc :x))
-          (is (contains? doc :z)))
-        (testing "authorization"
-          (testing "times called"
-            (is (called-once? ability/can?)))
-          (testing "action"
-            (is (call-matching? ability/can? (comp #{:read-property-y} first))))
-          (testing "object"
-            (is (call-matching? ability/can? (comp #{:qwerty} second)))))))))
+    (let [result @(p/select *dtc*)
+          doc (first result)]
+      (testing "marked property"
+        (is (not (contains? doc :y))))
+      (testing "unmarked properties"
+        (is (contains? doc :x))
+        (is (contains? doc :z)))
+      (testing "authorization"
+        (testing "times called"
+          (is (called-once? ability/can?)))
+        (testing "action"
+          (is (call-matching? ability/can? (comp #{:read-property-y} first))))
+        (testing "object"
+          (is (call-matching? ability/can? (comp #{:qwerty} second))))))))
+
+(comment (deftest creating
+  (testing "Adding to the store"
+    @(p/conj! *dtc* {:x "cba" :y "321" :z "zyx" :company-id (ObjectId.)})
+    (testing "marked property"
+      (is (call-matching? m/insert! (fn [[_ new-doc]]
+                                      (let [new-doc (peek (into [] new-doc))]
+                                        (not (contains? new-doc :y)))))))
+    (testing "unmarked property"
+      (is (call-matching? m/insert! (fn [[_ new-doc]]
+                                      (let [new-doc (peek (into [] new-doc))]
+                                        (contains? new-doc :z)))))))))
+
+(comment (deftest updating
+  (testing "Updating the store"
+    @(p/update-in! *dtc* {} {:y "321" :z "zyx"})
+    (testing "marked property"
+      (is (call-matching? m/update! (fn [[_ _ new-doc]]
+                                      (not (contains? new-doc :y))))))
+    (testing "unmarked property"
+      (is (call-matching? m/update! (fn [[_ _ new-doc]]
+                                      (contains? new-doc :z))))))))

--- a/domain/test/com/timezynk/domain/redaction_test.clj
+++ b/domain/test/com/timezynk/domain/redaction_test.clj
@@ -1,0 +1,48 @@
+(ns com.timezynk.domain.redaction-test
+  "Elevation of authorization barrier on a per-property basis"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+[clojure.tools.logging :as log]
+            [spy.core :refer [stub spy called-once? call-matching?]]
+            [com.timezynk.domain.core :refer [dom-type-collection]]
+            [com.timezynk.domain.schema :as s]
+            [com.timezynk.domain.mongo.core :as m]
+            [com.timezynk.useful.cancan :as ability]
+            [com.timezynk.domain.persistence :as p]))
+
+(def dtc
+  (dom-type-collection :name :qwerty
+                       :properties {:x (s/string)
+                                    :y (s/string :authorize-individually? true)
+                                    :z (s/string)}))
+
+(def ^:const records
+  [{:x "abc" :y "123" :z "xyz"}])
+
+(defn- with-immutable-inmemory-store [f]
+  (with-redefs [m/fetch         (stub records)
+                m/insert!       (stub {})
+                m/update-fast!  (spy (fn [_ _ doc] doc))
+                m/update!       (spy (fn [_ _ doc] doc))
+                m/destroy-fast! (stub {})
+                m/destroy!      (stub {})]
+    (f)))
+
+(use-fixtures :once #'with-immutable-inmemory-store)
+
+(deftest reading
+  (testing "Reading from the store"
+    (with-redefs [ability/can? (stub false)]
+      (let [result @(p/select dtc)
+            doc (first result)]
+        (testing "marked property"
+          (is (not (contains? doc :y))))
+        (testing "unmarked properties"
+          (is (contains? doc :x))
+          (is (contains? doc :z)))
+        (testing "authorization"
+          (testing "times called"
+            (is (called-once? ability/can?)))
+          (testing "action"
+            (is (call-matching? ability/can? (comp #{:read-property-y} first))))
+          (testing "object"
+            (is (call-matching? ability/can? (comp #{:qwerty} second)))))))))

--- a/domain/test/com/timezynk/domain/utils.clj
+++ b/domain/test/com/timezynk/domain/utils.clj
@@ -1,0 +1,16 @@
+(ns com.timezynk.domain.utils
+  (:require [spy.core :refer [stub]]
+            [com.timezynk.domain.mongo.core :as m]))
+
+(defn build-immutable-inmemory-store
+  "Builds a fixture which overrides mongo.core functions so that the end result
+   is an immutable store. The store resides wholly in memory."
+  [records]
+  (fn [f]
+    (with-redefs [m/fetch         (stub records)
+                  m/insert!       (stub records)
+                  m/update-fast!  (stub records)
+                  m/update!       (stub records)
+                  m/destroy-fast! (stub {})
+                  m/destroy!      (stub {})]
+      (f))))


### PR DESCRIPTION
## Why?

When reading / creating / editing documents, we often want to leave some properties out. Checking property names against lists of sensitive fields is error-prone, cumbersome and composes poorly.

## What?

This PR introduces a `mask` DTC property configuration option. The option expects a function, which should evaluate to truthy if the property needs redaction.

Usage:
``` clj
(defn redact?
  [dtc doc action property-name]
  (cond (contains? sensitive property-name) true
        (contains? readonly property-name)  (case action
                                              :read false
                                              :create true
                                              :update true)
        :else                               false))

(def widgets
  (dom-type-collection :name :widgets
                             :properties {:x (s/string)
                                          :y (s/string :mask redact?)
                                          :z (s/string :mask redact?)}))
```

## How?

The `mask` becomes part of the core pipeline, i.e. is made available to both `com.timezynk.domain.persistence` and `com.timezynk.domain.core/rest-routes`.

When reading (i.e. `GET` requests, index requests, `p/select`), properties which qualify for masking are removed from the results before rendering.

When writing (i.e. `POST`, `PUT`, `p/conj!`, `p/update-in!`), properties which qualify for masking are not included in the database queries.

## OOB maskers

This PR comes with a handy function (`com.timezynk.domain.dtc.masks/authorization`) which checks a property using the authorization framework. If the signed-in user has the `:[action]-property-[name]` ability, then the property will not be redacted.

For example, when fetching from `widgets`, the `:y` property won't be included unless the signed-in user has the `:read-property-y` ability on the `:widgets` object.