### PR TITLE
Bugfix: permissive authorization mask

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -7,7 +7,7 @@
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.0"]
-                 [com.timezynk/useful "1.14.0"]
+                 [com.timezynk/useful "1.17.0"]
                  [compojure "1.5.1" :scope "provided"]
                  [congomongo "2.1.0" :scope "provided"]
                  [org.clojure/clojure "1.10.1" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.6.0"
+(defproject com.timezynk/domain "1.6.1"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/dtc/masks.clj
+++ b/domain/src/com/timezynk/domain/dtc/masks.clj
@@ -1,13 +1,16 @@
 (ns com.timezynk.domain.dtc.masks
   "Useful functions for masking DTC properties."
-  (:require [com.timezynk.useful.cancan :as ability]
+  (:require [com.timezynk.useful.cancan :refer [can? *ability*]]
             [com.timezynk.domain.core :as c]))
 
-(defn authorization
-  "True if doc is missing authorization to contain the incoming property."
+(defn unauthorized?
+  "Truthy if doc is missing authorization to contain the incoming property.
+   Truthy if the cancan/*ability* object is unbound.
+   Falsy, otherwise."
   [dtc doc action property-name]
-  (let [action (keyword (format "%s-property-%s"
-                                (name action)
-                                (name property-name)))
-        object (c/get-dtc-name dtc)]
-    (not (ability/can? action object doc))))
+  (when (bound? #'*ability*)
+    (let [action (keyword (format "%s-property-%s"
+                                  (name action)
+                                  (name property-name)))
+          object (c/get-dtc-name dtc)]
+      (not (can? action object doc)))))

--- a/domain/src/com/timezynk/domain/dtc/masks.clj
+++ b/domain/src/com/timezynk/domain/dtc/masks.clj
@@ -1,16 +1,16 @@
 (ns com.timezynk.domain.dtc.masks
   "Useful functions for masking DTC properties."
-  (:require [com.timezynk.useful.cancan :refer [can? *ability*]]
+  (:require [com.timezynk.useful.cancan :as ability]
             [com.timezynk.domain.core :as c]))
 
 (defn unauthorized?
   "Truthy if doc is missing authorization to contain the incoming property.
-   Truthy if the cancan/*ability* object is unbound.
+   Truthy if not called within a cancan scope.
    Falsy, otherwise."
   [dtc doc action property-name]
-  (when (bound? #'*ability*)
+  (when (ability/in-scope?)
     (let [action (keyword (format "%s-property-%s"
                                   (name action)
                                   (name property-name)))
           object (c/get-dtc-name dtc)]
-      (not (can? action object doc)))))
+      (not (ability/can? action object doc)))))

--- a/domain/src/com/timezynk/domain/mask.clj
+++ b/domain/src/com/timezynk/domain/mask.clj
@@ -1,0 +1,44 @@
+(ns com.timezynk.domain.mask
+  (:require [clojure.string :as string]))
+
+(defn- recurse?
+  [property]
+  (= :map (:type (val property))))
+
+(defn- build-predicate
+  "Builds a predicate which decides whether a (potentially nested) property
+   should be removed from the document."
+  [dtc doc action]
+  (fn [trail]
+    (let [mask (get-in dtc (concat (interleave (repeat :properties) trail)
+                                   [:mask]))]
+      (and (fn? mask)
+           (mask dtc doc action (->> trail
+                                     (map name)
+                                     (string/join \.)))))))
+
+(defn- mask*
+  "Redacts all properties from doc for which redact? is true.
+   Recurses for :map properties."
+  [redact? dtc doc trail]
+  (reduce (fn [acc property]
+            (let [property-name (key property)
+                  trail (conj trail property-name)]
+              (cond-> acc
+                (redact? trail) (dissoc property-name)
+                (recurse? property)    (assoc property-name
+                                              (mask* redact?
+                                                     (val property)
+                                                     (get acc property-name)
+                                                     trail)))))
+             doc
+             (:properties dtc)))
+
+(defn build-station
+  "Builds a station which redacts from doc those properties, which:
+    * have been marked for masking
+    * pass the mask test"
+  [action]
+  (fn [dtc doc]
+    (let [redact? (build-predicate dtc doc action)]
+      (mask* redact? dtc doc []))))

--- a/domain/src/com/timezynk/domain/mask.clj
+++ b/domain/src/com/timezynk/domain/mask.clj
@@ -1,4 +1,22 @@
 (ns com.timezynk.domain.mask
+  "Implementation of DTC property masks.
+
+   A property is redacted from the document if the following conditions are met:
+    * property has been annotated with a :mask f attribute
+    * f is a function
+    * (f dtc doc action property-name) is truthy at the time of deferral
+
+   Example:
+   (defn mf
+     \"Property :y is read-only, disable writing!\"
+     [dtc doc action property-name]
+     (not= :read action))
+
+   (def dtc
+     (dom-type-collection :name :qwerty
+                          :properties {:x (s/string)
+                                       :y (s/string :mask mf)
+                                       :z (s/string)}))"
   (:require [clojure.string :as string]))
 
 (defn- recurse?

--- a/domain/src/com/timezynk/domain/mask/built_in.clj
+++ b/domain/src/com/timezynk/domain/mask/built_in.clj
@@ -1,4 +1,4 @@
-(ns com.timezynk.domain.dtc.masks
+(ns com.timezynk.domain.mask.built-in
   "Useful functions for masking DTC properties."
   (:require [com.timezynk.useful.cancan :as ability]
             [com.timezynk.domain.core :as c]))

--- a/domain/test/com/timezynk/domain/dtc/masks_test.clj
+++ b/domain/test/com/timezynk/domain/dtc/masks_test.clj
@@ -26,7 +26,7 @@
     (f)))
 
 (defn- with-authorization-failure [f]
-  (binding [ability/*ability* {}]
+  (ability/with-ability
     (with-redefs [ability/can? (stub false)]
       (f))))
 

--- a/domain/test/com/timezynk/domain/dtc/masks_test.clj
+++ b/domain/test/com/timezynk/domain/dtc/masks_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing compose-fixtures use-fixtures]]
             [spy.core :refer [stub spy called-once? call-matching?]]
             [com.timezynk.domain.core :as c]
-            [com.timezynk.domain.dtc.masks :refer [authorization]]
+            [com.timezynk.domain.dtc.masks :refer [unauthorized?]]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.mongo.core :as m]
             [com.timezynk.useful.cancan :as ability]
@@ -14,7 +14,7 @@
 
 (def ^:const dtc-properties
   {:x (s/string)
-   :y (s/string :mask authorization)
+   :y (s/string :mask unauthorized?)
    :z (s/string)})
 
 (def ^:const records
@@ -26,8 +26,9 @@
     (f)))
 
 (defn- with-authorization-failure [f]
-  (with-redefs [ability/can? (stub false)]
-    (f)))
+  (binding [ability/*ability* {}]
+    (with-redefs [ability/can? (stub false)]
+      (f))))
 
 (use-fixtures :each (->> create-dtc
                          (compose-fixtures (u/build-immutable-inmemory-store records))

--- a/domain/test/com/timezynk/domain/dtc/masks_test.clj
+++ b/domain/test/com/timezynk/domain/dtc/masks_test.clj
@@ -1,6 +1,6 @@
 (ns com.timezynk.domain.dtc.masks-test
   (:require [clojure.test :refer [deftest is testing compose-fixtures use-fixtures]]
-            [spy.core :refer [stub spy called-once? call-matching?]]
+            [spy.core :refer [stub spy called-n-times? call-matching?]]
             [com.timezynk.domain.core :as c]
             [com.timezynk.domain.dtc.masks :refer [unauthorized?]]
             [com.timezynk.domain.schema :as s]
@@ -15,10 +15,16 @@
 (def ^:const dtc-properties
   {:x (s/string)
    :y (s/string :mask unauthorized?)
-   :z (s/string)})
+   :z (s/map {:z1 (s/string)
+              :z2 (s/string :mask unauthorized?)
+              :z3 (s/string)})})
 
 (def ^:const records
-  [{:x "abc" :y "123" :z "xyz"}])
+  [{:x "abc"
+    :y "123"
+    :z {:z1 "xyz-1"
+        :z2 "xyz-2"
+        :z3 "xyz-3"}}])
 
 (defn- create-dtc [f]
   (binding [*dtc* (c/dom-type-collection :name :qwerty
@@ -43,32 +49,71 @@
       (testing "unmarked properties"
         (is (contains? doc :x))
         (is (contains? doc :z)))
+      (testing "marked nested property"
+        (is (not (contains? (:z doc) :z2))))
+      (testing "unmarked nested properties"
+        (is (contains? (:z doc) :z1))
+        (is (contains? (:z doc) :z3)))
       (testing "authorization"
         (testing "times called"
-          (is (called-once? ability/can?)))
-        (testing "action"
+          (is (called-n-times? ability/can? 2)))
+        (testing "top-level property action"
           (is (call-matching? ability/can? (comp #{:read-property-y} first))))
+        (testing "nested property action"
+          (is (call-matching? ability/can? (comp #{:read-property-z.z2} first))))
         (testing "object"
           (is (call-matching? ability/can? (comp #{:qwerty} second))))))))
 
+(defn- mask-matcher
+  "Builds a predicate suitable for spy.core/call-matching? which checks whether
+   a (potentially nested) property is present in the incoming document."
+  [masked? property-path]
+  (let [prefix (pop property-path)
+        property (peek property-path)]
+    (fn [doc]
+      (cond-> doc
+        (not-empty prefix) (get-in prefix)
+        true (contains? property)
+        masked? (not)))))
+
 (deftest creating
-  (testing "Adding to the store"
-    @(p/conj! *dtc* {:x "cba" :y "321" :z "zyx" :company-id (ObjectId.)})
-    (testing "marked property"
-      (is (call-matching? m/insert! (fn [[_ new-doc]]
-                                      (let [new-doc (peek (into [] new-doc))]
-                                        (not (contains? new-doc :y)))))))
-    (testing "unmarked property"
-      (is (call-matching? m/insert! (fn [[_ new-doc]]
-                                      (let [new-doc (peek (into [] new-doc))]
-                                        (contains? new-doc :z))))))))
+  (let [args->doc #(->> % last (into []) (peek))
+        masked #(comp (mask-matcher true %) args->doc)
+        not-masked #(comp (mask-matcher false %) args->doc)]
+    (testing "Adding to the store"
+      @(p/conj! *dtc* {:x "cba"
+                       :y "321"
+                       :z {:z1 "zyx-1"
+                           :z2 "zyx-2"
+                           :z3 "zyx-3"}
+                       :company-id (ObjectId.)})
+      (testing "marked property"
+        (is (call-matching? m/insert! (masked [:y]))))
+      (testing "unmarked properties"
+        (is (call-matching? m/insert! (not-masked [:x])))
+        (is (call-matching? m/insert! (not-masked [:z]))))
+      (testing "marked nested property"
+        (is (call-matching? m/insert! (masked [:z :z2]))))
+      (testing "unmarked nested properties"
+        (is (call-matching? m/insert! (not-masked [:z :z1])))
+        (is (call-matching? m/insert! (not-masked [:z :z3])))))))
 
 (deftest updating
-  (testing "Updating the store"
-    @(p/update-in! *dtc* {} {:y "321" :z "zyx"})
-    (testing "marked property"
-      (is (call-matching? m/update! (fn [[_ _ new-doc]]
-                                      (not (contains? new-doc :y))))))
-    (testing "unmarked property"
-      (is (call-matching? m/update! (fn [[_ _ new-doc]]
-                                      (contains? new-doc :z)))))))
+  (let [masked #(comp (mask-matcher true %) last)
+        not-masked #(comp (mask-matcher false %) last)]
+    (testing "Updating the store"
+      @(p/update-in! *dtc* {} {:x "cba"
+                               :y "321"
+                               :z {:z1 "zyx-1"
+                                   :z2 "zyx-2"
+                                   :z3 "zyx-3"}})
+      (testing "marked property"
+        (is (call-matching? m/update! (masked [:y]))))
+      (testing "unmarked properties"
+        (is (call-matching? m/update! (not-masked [:x])))
+        (is (call-matching? m/update! (not-masked [:z]))))
+      (testing "marked nested property"
+        (is (call-matching? m/update! (masked [:z :z2]))))
+      (testing "unmarked nested properties"
+        (is (call-matching? m/update! (not-masked [:z :z1])))
+        (is (call-matching? m/update! (not-masked [:z :z3])))))))

--- a/domain/test/com/timezynk/domain/mask/built_in_test.clj
+++ b/domain/test/com/timezynk/domain/mask/built_in_test.clj
@@ -1,8 +1,8 @@
-(ns com.timezynk.domain.dtc.masks-test
+(ns com.timezynk.domain.mask.built-in-test
   (:require [clojure.test :refer [deftest is testing compose-fixtures use-fixtures]]
             [spy.core :refer [stub spy called-n-times? call-matching?]]
             [com.timezynk.domain.core :as c]
-            [com.timezynk.domain.dtc.masks :refer [unauthorized?]]
+            [com.timezynk.domain.mask.built-in :refer [unauthorized?]]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.mongo.core :as m]
             [com.timezynk.useful.cancan :as ability]


### PR DESCRIPTION
This PR settles on a permissive policy regarding the `com.timezynk.domain.dtc.masks/unauthorized?` mask.

If performing an authorization check is out of scope, then the property should not be redacted.