### PR TITLE
Bugfix: Validation papercuts

### DIFF
--- a/domain/src/com/timezynk/domain/pack.clj
+++ b/domain/src/com/timezynk/domain/pack.clj
@@ -195,8 +195,8 @@
       (.toString v))))
 
 (defmethod pack-property :object-id [_ v props]
-  (when (object-id? v)
-    (um/object-id v)))
+  (cond-> v
+    (object-id? v) (um/object-id)))
 
 (defmethod pack-property :date [trail v props]
   (try

--- a/domain/src/com/timezynk/domain/validation/only_these.clj
+++ b/domain/src/com/timezynk/domain/validation/only_these.clj
@@ -3,17 +3,21 @@
    [clojure.set :refer [difference]]
    [clojure.test :refer [deftest is]]))
 
+(defn- only-these* [entry valid-attributes]
+  (let [invalid-attrs (when-not (nil? valid-attributes)
+                        (-> (keys entry)
+                            set
+                            (difference (into #{} valid-attributes))))]
+    [(empty? invalid-attrs)
+     (reduce #(assoc %1 %2 "invalid attribute") {} invalid-attrs)]))
+
 (defn only-these
   "only these are valid attributes"
   [& valid-attributes]
   (fn [entry]
-    (let [invalid-attrs (when-not (nil? valid-attributes)
-                          (-> (keys entry)
-                              set
-                              (difference (into #{} valid-attributes))))]
-      (if (empty? invalid-attrs)
-        [true {}]
-        [false (apply merge (map (fn [attr] {attr "invalid attribute"}) invalid-attrs))]))))
+    (if (map? entry)
+      (only-these* entry valid-attributes)
+      [true {}])))
 
 (deftest test-only-these
   (is (= [true {}]
@@ -21,4 +25,6 @@
                                         :field2 ""})))
   (is (= [false {:field3 "invalid attribute"}]
          ((only-these :field1 :field2) {:field1 ""
-                                        :field3 ""}))))
+                                        :field3 ""})))
+  (is (= [true {}]
+         ((only-these :field1 :field2) 123))))

--- a/domain/src/com/timezynk/domain/validation/validate.clj
+++ b/domain/src/com/timezynk/domain/validation/validate.clj
@@ -112,9 +112,9 @@
 
 (deftest test-validate-vector
   (is (= [true {:field {}}]
-         (validate-vector false :field :string ["123"])))
-  (is (= [true {:field {}}]
-         (validate-vector false :field :number ["123"])))
+         (validate-vector false :field {:type :string} ["123"])))
+  (is (= [false {:field {0 "not a number"}}]
+         (validate-vector false :field {:type :number} ["123"])))
   (is (= [true {:field {}}]
          (validate-vector false
                           :field
@@ -136,7 +136,7 @@
                           :field
                           {:properties {:field1 {:type :string}}}
                           [{:field2 "123"}])))
-  (is (= [false {:field {:vector "not sequential"}}]
+  (is (= [false {:field "not sequential"}]
          (validate-vector false :field :string "123"))))
 
 (deftest test-get-check-fn
@@ -257,7 +257,7 @@
                           {:properties {:values {:type :vector
                                                  :children {:type :string}}}}
                           {:values ["123"]})))
-  (is (= [false {:values {:vector "not sequential"}}]
+  (is (= [false {:values "not sequential"}]
          (validate-schema false
                           {:properties {:values {:type :vector
                                                  :children {:type :string}}}}
@@ -273,7 +273,7 @@
                                 {:values "123"})]
     (is (= false (first result)))
     (is (= "not a map" (get-in result [1 :values]))))
-  (is (= [true {}]
+  (is (= [false {:values {0 "not a string"}}]
          (validate-schema false
                           {:properties {:values {:type :vector
                                                  :children {:type :string}}}}

--- a/domain/src/com/timezynk/domain/validation/validate.clj
+++ b/domain/src/com/timezynk/domain/validation/validate.clj
@@ -46,12 +46,14 @@
     :max        (check #(>= property-definition %)
                        property-name
                        (str "bigger than " property-definition))
-    :min-length (check #(and (check-by-length? %)
-                             (<= property-definition (count %)))
+    :min-length (check #(if (check-by-length? %)
+                          (<= property-definition (count %))
+                          true)
                        property-name
                        (str "shorter than " property-definition))
-    :max-length (check #(and (check-by-length? %)
-                             (>= property-definition (count %)))
+    :max-length (check #(if (check-by-length? %)
+                          (>= property-definition (count %))
+                          true)
                        property-name
                        (str "longer than " property-definition))
     :type       (validate-type property-name property-definition)
@@ -310,6 +312,16 @@
                                                 :children {:type :number}
                                                 :max-length 1}}}
                           {:field [1 2]})))
+  (is (= [true {}]
+         (validate-schema false
+                          {:properties {:field {:type :integer
+                                                :min-length 3}}}
+                          {:field 12})))
+  (is (= [true {}]
+         (validate-schema false
+                          {:properties {:field {:type :integer
+                                                :max-length 3}}}
+                          {:field 1234})))
   (is (= [false {:field "does not match [0-9]+"}]
          (validate-schema false
                           {:properties {:field {:type :string

--- a/domain/src/com/timezynk/domain/validation/validate.clj
+++ b/domain/src/com/timezynk/domain/validation/validate.clj
@@ -249,12 +249,12 @@
                           {:properties {:values {:type :map
                                                  :properties {:field2 {:type :string}}}}}
                           {:values {:field2 "123"}})))
-  (is (thrown?
-       java.lang.ClassCastException
-       (validate-schema false
-                        {:properties {:values {:type :map
-                                               :properties {:field2 {:type :string}}}}}
-                        {:values "123"})))
+  (let [result (validate-schema false
+                                {:properties {:values {:type :map
+                                                       :properties {:field2 {:type :string}}}}}
+                                {:values "123"})]
+    (is (= false (first result)))
+    (is (= "not a map" (get-in result [1 :values]))))
   (is (= [true {}]
          (validate-schema false
                           {:properties {:values {:type :vector

--- a/domain/src/com/timezynk/domain/validation/validate.clj
+++ b/domain/src/com/timezynk/domain/validation/validate.clj
@@ -22,6 +22,9 @@
       [valid? {attr-name errors}])
     [false {attr-name {:vector "not sequential"}}]))
 
+(def ^:private check-by-length?
+  (some-fn string? vector? map?))
+
 (defn- get-check-fn [all-optional? k property-name property-definition]
   (case k
     :min        (check #(<= property-definition %)
@@ -30,10 +33,12 @@
     :max        (check #(>= property-definition %)
                        property-name
                        (str "bigger than " property-definition))
-    :min-length (check #(<= property-definition (count %))
+    :min-length (check #(and (check-by-length? %)
+                             (<= property-definition (count %)))
                        property-name
                        (str "shorter than " property-definition))
-    :max-length (check #(>= property-definition (count %))
+    :max-length (check #(and (check-by-length? %)
+                             (>= property-definition (count %)))
                        property-name
                        (str "longer than " property-definition))
     :type       (validate-type property-name property-definition)

--- a/domain/test/com/timezynk/domain/pack_test.clj
+++ b/domain/test/com/timezynk/domain/pack_test.clj
@@ -78,3 +78,10 @@
                      :route-params {:company-id (um/object-id "5f08667cfc3107569d6deb79")}}
             result (p/pack-query dtc request)]
         (is (-> result :some :path.to :id (um/object-id?)))))))
+
+(deftest pack-doc-test
+  (testing "Should pack malformed ObjectId values"
+    (let [packed (p/pack-doc coll {:message "hi"
+                                   :related-id "not-an-objectid"
+                                   :grade 10})]
+      (is (= "not-an-objectid" (:related-id packed))))))

--- a/domain/test/com/timezynk/domain/schema/map_test.clj
+++ b/domain/test/com/timezynk/domain/schema/map_test.clj
@@ -1,4 +1,4 @@
-(ns com.timezynk.domain.schema-test
+(ns com.timezynk.domain.schema.map-test
   (:require [clojure.test :refer [deftest is are testing]]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.validation.validate :refer [validate-schema]])

--- a/domain/test/com/timezynk/domain/schema/vector_test.clj
+++ b/domain/test/com/timezynk/domain/schema/vector_test.clj
@@ -1,0 +1,40 @@
+(ns com.timezynk.domain.schema.vector-test
+  (:require [clojure.test :refer [deftest is are testing]]
+            [com.timezynk.domain.schema :as s]
+            [com.timezynk.domain.validation.validate :refer [validate-schema]])
+  (:import [org.bson.types ObjectId]))
+
+(def ^:const valid-value
+  [1 2 3])
+
+(defn- validator [value]
+  (validate-schema false
+                   {:properties {:field (s/vector (s/integer))}}
+                   {:field value}))
+
+(deftest valid
+  (is (= [true {}]
+         (validator valid-value))))
+
+(deftest vector-value-not-matching-item-type
+  (testing "type mismatch within vector"
+    (let [invalid-value-1 (update valid-value 0 str)
+          invalid-value-2 (update valid-value 1 boolean)
+          invalid-value-3 (update valid-value 2 #(hash-map :x %))]
+      (testing "string instead of integer"
+        (is (= [false {:field {0 "not an integer"}}]
+               (validator invalid-value-1))))
+      (testing "boolean instead of integer"
+        (is (= [false {:field {1 "not an integer"}}]
+               (validator invalid-value-2))))
+      (testing "map instead of integer"
+        (is (= [false {:field {2 "not an integer"}}]
+               (validator invalid-value-3)))))))
+
+(deftest non-vector-instead-of-vector
+  (are [value] (let [[ok? errors] (validator value)]
+                 (and (false? ok?)
+                      (= "not sequential" (:field errors))))
+       "abc"
+       123
+       false))

--- a/domain/test/com/timezynk/domain/schema_test.clj
+++ b/domain/test/com/timezynk/domain/schema_test.clj
@@ -1,14 +1,10 @@
 (ns com.timezynk.domain.schema-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [spy.core :refer [stub spy called-once? call-matching?]]
-            [com.timezynk.useful.mongo :as um]
             [com.timezynk.domain.core :as c]
             [com.timezynk.domain.schema :as s]
-            [com.timezynk.domain.persistence :as p]
-            [com.timezynk.domain.utils :as u])
+            [com.timezynk.domain.persistence :as p])
   (:use [slingshot.test])
-  (:import [org.bson.types ObjectId]
-           [clojure.lang ExceptionInfo]))
+  (:import [org.bson.types ObjectId]))
 
 (def ^:dynamic *dtc*)
 

--- a/domain/test/com/timezynk/domain/schema_test.clj
+++ b/domain/test/com/timezynk/domain/schema_test.clj
@@ -1,0 +1,54 @@
+(ns com.timezynk.domain.schema-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [spy.core :refer [stub spy called-once? call-matching?]]
+            [com.timezynk.useful.mongo :as um]
+            [com.timezynk.domain.core :as c]
+            [com.timezynk.domain.schema :as s]
+            [com.timezynk.domain.persistence :as p]
+            [com.timezynk.domain.utils :as u])
+  (:use [slingshot.test])
+  (:import [org.bson.types ObjectId]
+           [clojure.lang ExceptionInfo]))
+
+(def ^:dynamic *dtc*)
+
+(def ^:const properties
+  {:x (s/id)
+   :y (s/map {:id (s/id)
+              :ref-no (s/integer)
+              :sold (s/boolean)})})
+
+(defn- create-dtc [f]
+  (binding [*dtc* (c/dom-type-collection :name :cars
+                                         :properties properties)]
+    (f)))
+
+(def ^:const valid-doc
+  {:x (ObjectId.)
+   :y {:id (ObjectId.)
+       :ref-no 42
+       :sold true}
+   :company-id (ObjectId.)})
+
+(use-fixtures :each create-dtc)
+
+(defn- insert! [doc]
+  @(p/conj! *dtc* doc))
+
+(deftest valid
+  (let [before @(p/select-count *dtc*)
+        _ (insert! valid-doc)
+        after @(p/select-count *dtc*)]
+    (is (= after (inc before)))))
+
+(deftest map-value-not-matching-key-type
+  (testing "Type mismatch within map"
+    (let [invalid-doc-1 (update-in valid-doc [:y :id] str)
+          invalid-doc-2 (update-in valid-doc [:y :ref-no] str)
+          invalid-doc-3 (assoc-in valid-doc [:y :sold] 1)]
+      (testing "string instead of ObjectId"
+        (is (thrown+? [:errors {:id "not a valid id"}] (insert! invalid-doc-1))))
+      (testing "string instead of integer"
+        (is (thrown+? [:errors {:ref-no "not an integer"}] (insert! invalid-doc-2))))
+      (testing "integer instead of boolean"
+        (is (thrown+? [:errors {:sold "not a boolean"}] (insert! invalid-doc-3)))))))

--- a/domain/test/com/timezynk/domain/schema_test.clj
+++ b/domain/test/com/timezynk/domain/schema_test.clj
@@ -38,13 +38,30 @@
     (is (= after (inc before)))))
 
 (deftest map-value-not-matching-key-type
-  (testing "Type mismatch within map"
+  (testing "type mismatch within map"
     (let [invalid-doc-1 (update-in valid-doc [:y :id] str)
           invalid-doc-2 (update-in valid-doc [:y :ref-no] str)
           invalid-doc-3 (assoc-in valid-doc [:y :sold] 1)]
       (testing "string instead of ObjectId"
-        (is (thrown+? [:errors {:id "not a valid id"}] (insert! invalid-doc-1))))
+        (is (thrown+? (= (get-in % [:errors :id]) "not a valid id")
+                      (insert! invalid-doc-1))))
       (testing "string instead of integer"
-        (is (thrown+? [:errors {:ref-no "not an integer"}] (insert! invalid-doc-2))))
+        (is (thrown+? (= (get-in % [:errors :ref-no]) "not an integer")
+                      (insert! invalid-doc-2))))
       (testing "integer instead of boolean"
-        (is (thrown+? [:errors {:sold "not a boolean"}] (insert! invalid-doc-3)))))))
+        (is (thrown+? (= (get-in % [:errors :sold]) "not a boolean")
+                      (insert! invalid-doc-3)))))))
+
+(deftest non-map-instead-of-map
+  (let [invalid-doc-1 (assoc valid-doc :y "abc")
+        invalid-doc-2 (assoc valid-doc :y 42)
+        invalid-doc-3 (assoc valid-doc :y false)]
+    (testing "string instead of map"
+      (is (thrown+? (= (get-in % [:errors :y]) "not a map")
+                    (insert! invalid-doc-1))))
+    (testing "integer instead of map"
+      (is (thrown+? (= (get-in % [:errors :y]) "not a map")
+                    (insert! invalid-doc-2))))
+    (testing "boolean instead of map"
+      (is (thrown+? (= (get-in % [:errors :y]) "not a map")
+                    (insert! invalid-doc-3))))))

--- a/domain/test/com/timezynk/domain/validation/length_test.clj
+++ b/domain/test/com/timezynk/domain/validation/length_test.clj
@@ -1,0 +1,65 @@
+(ns com.timezynk.domain.validation.length-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [com.timezynk.domain.validation.validate :refer [validate-schema]]))
+
+(defn- build-validator [spec]
+  (fn [value]
+    (validate-schema false
+                     {:properties {:field spec}}
+                     {:field value})))
+
+(deftest test-min-length
+  (testing "expecting string"
+    (let [f (build-validator {:type :string :min-length 3})]
+      (testing "string input"
+        (is (= [false {:field "shorter than 3"}]
+               (f "12"))))
+      (testing "integer input"
+        (is (= [false {:field "not a string"}]
+               (f 12))))))
+
+  (testing "expecting vector"
+    (let [f (build-validator {:type :vector :min-length 3})]
+      (testing "vector input"
+        (is (= [false {:field "shorter than 3"}]
+               (f [1 2]))))
+      (testing "string input"
+        (is (= [false {:field "not sequential"}]
+               (f "12"))))))
+
+  (testing "expecting map"
+    (let [f (build-validator {:type :map :min-length 3})]
+      (testing "map input"
+        (is (= [false {:field "shorter than 3"}]
+               (f {:x 1 :y 2}))))
+      (testing "string input"
+        (is (= [false {:field "not a map"}]
+               (f "12")))))))
+
+(deftest test-max-length
+  (testing "expecting string"
+    (let [f (build-validator {:type :string :max-length 2})]
+      (testing "string input"
+        (is (= [false {:field "longer than 2"}]
+               (f "123"))))
+      (testing "integer input"
+        (is (= [false {:field "not a string"}]
+               (f 123))))))
+
+  (testing "expecting vector"
+    (let [f (build-validator {:type :vector :max-length 2})]
+      (testing "vector input"
+        (is (= [false {:field "longer than 2"}]
+               (f [1 2 3]))))
+      (testing "string input"
+        (is (= [false {:field "not sequential"}]
+               (f "123"))))))
+
+  (testing "expecting map"
+    (let [f (build-validator {:type :map :max-length 2})]
+      (testing "map input"
+        (is (= [false {:field "longer than 2"}]
+               (f {:x 1 :y 2 :z 3}))))
+      (testing "string input"
+        (is (= [false {:field "not a map"}]
+               (f "123")))))))


### PR DESCRIPTION
Notes:
- `(s/id)`: `pack-doc` doesn't leave malformed values out
- `(s/map)`: fixes validation of non-map values
    ``` clj
    => (def dtc
         (c/dom-type-collection :name :xyz
                                :properties {:v (s/map {:id (s/id)})}))
    => (v/validate-properties false (:properties dtc) {:v 20 :company-id (ObjectId.)})
    [false {:v "not sequential"}]
    ```
- `(s/vector)`:
  - non-vector values:
    - fixes validation
      ``` clj
      => (def dtc
           (c/dom-type-collection :name :xyz
                                  :properties {:v (s/vector (s/number))}))
      => => (v/validate-properties false (:properties dtc) {:v 20 :company-id (ObjectId.)})
      [false {:v "not a map", :id "required property has no value"}]
      ```
    - doesn't nest error message in a `{:vector "..."}` hash
  - vector values:
    - validates each item separately
    - collects item error messages in a hash, keyed by index
      ``` clj
      => (def dtc
           (c/dom-type-collection :name :xyz
                                  :properties {:v (s/vector (s/number))}))
      => (v/validate-properties false (:properties dtc) {:v [10 "20"] :company-id (ObjectId.)})
      [false {:v {1 "not a number"}}]
      ```
- `:min-length` / `:max-length`: apply to `:string`, `:vector`, `:map` only