### PR TITLE
Bugfix: Masking station populates missing

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.6.1"
+(defproject com.timezynk/domain "1.6.2"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/mask.clj
+++ b/domain/src/com/timezynk/domain/mask.clj
@@ -39,18 +39,19 @@
   "Redacts all properties from doc for which redact? is true.
    Recurses for :map properties."
   [redact? dtc doc trail]
-  (reduce (fn [acc property]
-            (let [property-name (key property)
-                  trail (conj trail property-name)]
-              (cond-> acc
-                (redact? trail) (dissoc property-name)
-                (recurse? property)    (assoc property-name
-                                              (mask* redact?
-                                                     (val property)
-                                                     (get acc property-name)
-                                                     trail)))))
-             doc
-             (:properties dtc)))
+  (->> (:properties dtc)
+       (filter (comp (set (keys doc)) key))
+       (reduce (fn [acc property]
+                 (let [property-name (key property)
+                       trail (conj trail property-name)]
+                   (cond-> acc
+                     (redact? trail) (dissoc property-name)
+                     (recurse? property) (assoc property-name
+                                                (mask* redact?
+                                                       (val property)
+                                                       (get acc property-name)
+                                                       trail)))))
+               doc)))
 
 (defn build-station
   "Builds a station which redacts from doc those properties, which:


### PR DESCRIPTION
A bug in the implementation of `:mask` is causing missing `:type :map` properties to be added to the document with a `nil` value.