### PR TITLE
Bugfix: Masks don't honor :default and :derived

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.6.2"
+(defproject com.timezynk/domain "1.6.3"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -300,8 +300,8 @@
                                       (partial validate-properties! true)
                                       validate-properties2!
                                       validate-doc!]
-                       :pre-process  (add-derived-values true)
                        :mask         (mask/build-station :update)
+                       :pre-process  (add-derived-values true)
                        :execute      execute-update!
                        :deref        deref-steps]
                       :wrapper-f wrapper-f

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -288,8 +288,8 @@
                                       validate-properties2!
                                       validate-doc!
                                       validate-id-availability]
-                       :pre-process  [add-default-values (add-derived-values false)]
                        :mask         (mask/build-station :create)
+                       :pre-process  [add-default-values (add-derived-values false)]
                        :execute      execute-insert!
                        :deref        deref-steps]
                       :wrapper-f wrapper-f

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -465,7 +465,6 @@
                                                       (pre-process-dtc :put dom-type-collection req)
                                                       dom-type-collection)
                                 restriction         (pack/pack-query dom-type-collection req)
-                                collects            (pack/pack-collects dom-type-collection req)
                                 document            (pack/pack-update dom-type-collection req)]
                             (-> (p/update-in! dom-type-collection restriction document)
                                 pack-station

--- a/domain/src/com/timezynk/domain/mask.clj
+++ b/domain/src/com/timezynk/domain/mask.clj
@@ -53,11 +53,20 @@
                                                        trail)))))
                doc)))
 
+(defn- any-masks?
+  "Truthy if any property bears a :mask attribute, falsy otherwise.
+   Recurses into :map properties."
+  [dtc]
+  (some (some-fn (comp fn? :mask val)
+                 (every-pred recurse? (comp any-masks? val)))
+        (:properties dtc)))
+
 (defn build-station
   "Builds a station which redacts from doc those properties, which:
     * have been marked for masking
     * pass the mask test"
   [action]
   (fn [dtc doc]
-    (let [redact? (build-predicate dtc doc action)]
-      (mask* redact? dtc doc []))))
+    (if (any-masks? dtc)
+      (mask* (build-predicate dtc doc action) dtc doc [])
+      doc)))

--- a/domain/test/com/timezynk/domain/mask/utils.clj
+++ b/domain/test/com/timezynk/domain/mask/utils.clj
@@ -1,0 +1,9 @@
+(ns com.timezynk.domain.mask.utils)
+
+(defn action-matcher [value]
+  (fn [[_ _ action _]]
+    (= value action)))
+
+(defn property-name-matcher [value]
+  (fn [[_ _ _ property-name]]
+    (= value property-name)))

--- a/domain/test/com/timezynk/domain/mask_test.clj
+++ b/domain/test/com/timezynk/domain/mask_test.clj
@@ -1,0 +1,74 @@
+(ns com.timezynk.domain.mask-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [spy.core :as spy]
+            [com.timezynk.domain.core :refer [dom-type-collection]]
+            [com.timezynk.domain.mask.utils :as mu]
+            [com.timezynk.domain.mongo.core :as m]
+            [com.timezynk.domain.persistence :as p]
+            [com.timezynk.domain.schema :as s]
+            [com.timezynk.domain.utils :as u])
+  (:import [org.bson.types ObjectId]))
+
+(deftest fetch
+  (let [f (spy/stub true)
+        dtc (dom-type-collection :name :qwerty
+                                 :properties {:x (s/string :mask f)
+                                              :y (s/string)})
+        original-doc {:x "abc" :y "123"}
+        result-doc (with-redefs [m/fetch (spy/stub [original-doc])]
+                     (p/->1 dtc p/select))]
+    (testing "property presence"
+      (is (not (contains? result-doc :x)))
+      (is (contains? result-doc :y)))
+    (testing "masking function"
+      (testing "calls"
+        (is (spy/called-once? f)))
+      (testing "action"
+        (is (spy/call-matching? f (mu/action-matcher :read))))
+      (testing "property-name"
+        (is (spy/call-matching? f (mu/property-name-matcher "x")))))))
+
+(deftest fetch-nested
+  (let [f (spy/stub true)
+        dtc (dom-type-collection :name :qwerty
+                                 :properties {:x (s/map {:z (s/string :mask f)})
+                                              :y (s/string)})
+        original-doc {:x {:z "123"} :y "abc"}
+        result-doc (with-redefs [m/fetch (spy/stub [original-doc])]
+                     (p/->1 dtc p/select))]
+    (testing "property presence"
+      (is (contains? result-doc :x))
+      (is (not (contains? (:x result-doc) :z))))
+    (testing "masking function property-name"
+      (is (spy/call-matching? f (mu/property-name-matcher "x.z"))))))
+
+(deftest create
+  (let [f (spy/stub true)
+        dtc (dom-type-collection :name :qwerty
+                                 :properties {:x (s/string :mask f)
+                                              :y (s/string)})
+        original-doc {:x "123" :y "abc" :company-id (ObjectId.)}
+        result-doc (with-redefs [m/insert! (spy/spy (fn [_ docs]
+                                                      (into [] docs)))]
+                     (p/->1 dtc (p/conj! original-doc)))]
+    (testing "property presence"
+      (is (not (contains? result-doc :x)))
+      (is (contains? result-doc :y)))
+    (testing "masking function"
+      (testing "calls"
+        (is (spy/called-once? f)))
+      (testing "action"
+        (is (spy/call-matching? f (mu/action-matcher :create))))
+      (testing "property-name"
+        (is (spy/call-matching? f (mu/property-name-matcher "x")))))))
+
+(deftest create-with-default
+  (let [f (spy/stub true)
+        dtc (dom-type-collection :name :qwerty
+                                 :properties {:x (s/string :mask f
+                                                           :default "!")})
+        original-doc {:x "123" :company-id (ObjectId.)}
+        result-doc (with-redefs [m/insert! (spy/spy (fn [_ docs]
+                                                      (into [] docs)))]
+                     (p/->1 dtc (p/conj! original-doc)))]
+    (is (= "!" (:x result-doc)))))


### PR DESCRIPTION
Notes:
- on `insert`: applies `:mask` before adding `:default` values
- on `update`: applies `:mask` before adding `:derived` values
- on `mask`: walks document only if property tree contains `:mask` attributes