### PR TITLE
Bugfix: Validation of vector of optional items throws exception

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.6.4"
+(defproject com.timezynk/domain "1.6.5"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/validation/validate.clj
+++ b/domain/src/com/timezynk/domain/validation/validate.clj
@@ -77,7 +77,7 @@
              (not (contains? property-value property-name)))
         (and (or (:optional? property-definition)
                  (some? (:default property-definition)))
-             (nil? (property-name property-value)))
+             (nil? (get property-value property-name)))
         (:computed property-definition)
         (:derived property-definition))))
 
@@ -139,7 +139,13 @@
                           {:properties {:field1 {:type :string}}}
                           [{:field2 "123"}])))
   (is (= [false {:field {:vector "not sequential"}}]
-         (validate-vector false :field :string "123"))))
+         (validate-vector false :field :string "123")))
+  (is (= [false {:field {:field1 "not an integer"}}]
+         (validate-vector false
+                          :field
+                          {:properties {:field1 {:type :integer}}
+                           :optional? true}
+                          [{:field1 "123"}]))))
 
 (deftest test-get-check-fn
   (with-redefs [check (spy/stub)]


### PR DESCRIPTION
DTC field specified like so:

``` clj
{:orders (s/vector (s/map {:id (s/id :optional? true)
                           :no (s/integer :optional? true)}
                          :optional? true)
                   :optional? true)}
```

Throws when passed the following document:

``` json
{
  "orders": [
    {
      "id": "6350fec7be4f440d9b02eb0a",
      "no": 1
    }
  ]
}
```