### PR TITLE
Feature: Dependency cleanup

### DIFF
--- a/assembly_line/project.clj
+++ b/assembly_line/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/assembly-line "1.0.0"
+(defproject com.timezynk/assembly-line "1.0.1"
   :description "Designed to create data workflows with different stations where the processing can be done. The assembly line can easily be extend with new stations, you can run it up to a specific station, pause it, resume it and execute it asynchronously."
   :url "https://github.com/TimeZynk/domain/tree/master/assembly_line"
   :license {:name "BSD 3 Clause"

--- a/assembly_line/project.clj
+++ b/assembly_line/project.clj
@@ -6,5 +6,5 @@
   :scm {:name "git"
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [
-    [org.clojure/clojure "1.10.1" :scope "provided"]
+    [org.clojure/clojure "1.11.1" :scope "provided"]
   ])

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -5,14 +5,12 @@
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :scm {:name "git"
         :url  "https://github.com/TimeZynk/domain"}
-  :dependencies [[ch.qos.logback/logback-classic "1.4.6"]
-                 [com.novemberain/validateur "2.6.0"]
+  :dependencies [[com.novemberain/validateur "2.6.0"]
                  [com.timezynk/assembly-line "1.0.0"]
                  [com.timezynk/useful "1.20.13"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
-                 [org.clojure/tools.logging "1.2.4"]
                  [slingshot "0.12.2"]
                  [tortue/spy "2.13.0"]]
   :repl-options {:init-ns com.timezynk.domain.core}
@@ -20,6 +18,4 @@
   :plugins [[lein-cljfmt "0.6.7"]]
   :profiles {:kaocha {:dependencies [[lambdaisland/kaocha "1.0.632"]]
                       :jvm-opts ["-Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2"]}}
-
-  :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
   :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]})

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -7,7 +7,7 @@
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.0"]
-                 [com.timezynk/useful "1.20.13"]
+                 [com.timezynk/useful "2.0.0"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -5,7 +5,7 @@
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :scm {:name "git"
         :url  "https://github.com/TimeZynk/domain"}
-  :dependencies [[com.novemberain/validateur "2.6.0"]
+  :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.0"]
                  [com.timezynk/useful "1.20.13"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "1.6.10"
+(defproject com.timezynk/domain "1.7.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/migrations/collection_header.clj
+++ b/domain/src/com/timezynk/domain/migrations/collection_header.clj
@@ -1,0 +1,67 @@
+(ns com.timezynk.domain.migrations.collection-header
+  "The collection header adds information about migrations"
+  (:require [com.timezynk.domain.core :as dom]
+          ; [com.timezynk.domain.schema :as s]
+            [somnium.congomongo :as mongo]))
+
+(comment
+  (def collection-headers
+    (-> (dom/dom-type-collection
+         :name :collection-headers
+         :description "The collection header adds information about migrations"
+         :properties {:migrations (s/any :default (fn [_] {}))
+                      :info       (s/any :default (fn [_] {}))})
+        (update-in [:properties]
+                   dissoc
+                   :created
+                   :created-by
+                   :changed-by
+                   :company-id)
+        (assoc-in [:properties :id] (s/string)))))
+
+(defn by-collection [collection]
+  (mongo/fetch-one :collection.headers
+                   :where {:_id (if (keyword? collection)
+                                  collection
+                                  (dom/collection-name collection))}))
+
+(defn migration-made? [collection migr-name]
+  (let [collection-name (if (keyword? collection)
+                          collection
+                          (dom/collection-name collection))]
+    (boolean
+     (mongo/fetch-one :collection.headers
+                      :where {:_id collection-name
+                              (str "migrations." (name migr-name)) {:$exists true}}))))
+
+(defn create! [collection migration-name source-collection]
+  (let [collection-name (if (keyword? collection)
+                          collection
+                          (dom/collection-name collection))
+        header?         (mongo/fetch-one :collection.headers
+                                         :where {:_id collection-name})]
+    (when-not header?
+      (mongo/insert! :collection.headers
+                     {:_id           collection-name
+                      migration-name {:source-collection source-collection}}))))
+
+(defn update! [dom-type-collection new-doc]
+  (let [collection-name (dom/collection-name dom-type-collection)]
+    (mongo/update! :collection.headers
+                   {:_id collection-name}
+                   new-doc)))
+
+(defn set-migration-not-made! [collection migr-name]
+  (mongo/update! :collection.headers
+                 {:_id (if (keyword? collection)
+                         collection
+                         (dom/collection-name collection))}
+                 {:$set {(str "migrations." (name migr-name)) false}}))
+
+(defn migration-finished [collection migr-name]
+  (let [collection-name (if (keyword? collection)
+                          collection
+                          (dom/collection-name collection))]
+    (mongo/update! :collection.headers
+                   {:_id collection-name}
+                   {:$set {(str "migrations." (name migr-name)) (System/currentTimeMillis)}})))

--- a/domain/src/com/timezynk/domain/migrations/utils.clj
+++ b/domain/src/com/timezynk/domain/migrations/utils.clj
@@ -1,0 +1,117 @@
+(ns com.timezynk.domain.migrations.utils
+  (:require
+   [clojure.tools.logging :as log]
+   [com.timezynk.domain.migrations.collection-header :as h]
+   ; [com.timezynk.domain.core :as dom]
+   [somnium.congomongo :as mongo]))
+
+(defn time-info [t-name company-name label f & args]
+  (let [ts  (System/currentTimeMillis)
+        res (apply f args)
+        s   (int (/ (- (System/currentTimeMillis) ts) 1000))]
+    (log/info t-name company-name ">>" label "took" s "seconds to complete <<")
+    res))
+
+                                        ; docompanies
+
+(def company-counter
+  (let [c (atom 0)]
+    (fn []
+      (swap! c inc))))
+
+(defn- docompany [company f]
+  (comment time-info (.getName (Thread/currentThread))
+           (:name company)
+           "migration"
+           f
+           company)
+  (f company))
+
+(defn- create-worker [companies f]
+  (bound-fn []
+    (loop [{:keys [company-id]} (.poll companies)]
+      (when company-id
+        (when-let [company (mongo/fetch-by-id :companies company-id :only [:name])]
+          (try
+            (log/info (.getName (Thread/currentThread)) "start migration for company #"
+                      (company-counter) ":" (:name company) "(" (str (:_id company)) ") left to go:"
+                      (.size companies))
+            (docompany company f)
+            (catch Exception e
+              (log/error e (.getName (Thread/currentThread)) "failed to migrate company" company))))
+        (recur (.poll companies))))
+    (log/info (.getName (Thread/currentThread)) "finished")))
+
+(defn- spawn-worker! [f companies]
+  (let [^Thread t (Thread. (create-worker companies f))]
+    (.start t)
+    t))
+
+(defn- spawn-workers! [companies n f]
+  (doall (map (partial spawn-worker! f) (repeat n companies))))
+
+(defn- build-companies-queue []
+  (java.util.concurrent.ConcurrentLinkedQueue.
+   (->> (mongo/fetch :companies :only [:_id])
+        (map (fn [company] {:company-id (:_id company)})))))
+
+(defn docompanies
+  "do stuff per company"
+  ([f] (docompanies f 4))
+  ([f num-workers]
+   (try
+     (let [companies (build-companies-queue)
+           workers   (spawn-workers! companies num-workers f)]
+       (doseq [^Thread w workers]
+         (log/info "Waiting for thread" (.getName w))
+         (.join w)
+         (log/info "Joined" (.getName w)))
+       true)
+     (catch Exception e (log/error e)))))
+
+                                        ; migration
+
+(defn continue? [migr-name collections]
+  (every? true?
+          (map #(not (h/migration-made? % migr-name)) collections)))
+
+(defn finished! [migr-name collections]
+  (doseq [c collections]
+    (h/migration-finished c migr-name)))
+
+(defn migration [migr-name & {:keys [task collections]}]
+  (fn []
+    (let [migr-name (keyword migr-name)]
+      (try
+        (when (continue? migr-name collections)
+          (log/info "execute" migr-name)
+          (if (task)
+            (do (log/info "migration" migr-name "finished")
+                (finished! migr-name collections))
+            (log/info "migration" migr-name "did not finish")))
+        (catch Exception e
+          (log/error e "Migration failed"))))))
+
+(defn migration-wrapper [migr]
+  (fn [db]
+    (mongo/with-mongo db
+      (migr))))
+
+                                        ; memory database
+
+#_(def ^:dynamic *memory* nil)
+
+#_(def ^:dynamic *now* nil)
+
+#_(defn execute! [_ doc]
+    (swap! *memory* conj
+           (-> doc
+               (rename-keys {:id :_name})
+               (assoc :valid-from *now*))))
+
+#_(defmacro batch [domain-type-collection & body]
+    `(binding [*memory* (atom [])
+               *now*    (System/currentTimeMillis)]
+       ~@body
+       (mongo/mass-insert! (dom/collection-name domain-type-collection)
+                           @*memory*)))

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -3,10 +3,10 @@
   :url "http://example.com/FIXME"
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[com.timezynk/domain "1.1.0"]
-                 [com.timezynk/useful "1.13.4" :scope "dev"]
-                 [congomongo "2.2.1" :scope "provided"]
-                 [org.clojure/clojure "1.10.0" :scope "provided"]
+  :dependencies [[com.timezynk/domain "1.7.0"]
+                 [com.timezynk/useful "2.0.0" :scope "dev"]
+                 [congomongo "2.6.0" :scope "provided"]
+                 [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]
   :repl-options {:init-ns domain-types.core}
   :plugins [[lein-cljfmt "0.6.7"]])

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain-types "1.0.2"
+(defproject com.timezynk/domain-types "1.0.3"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "BSD 3 Clause"


### PR DESCRIPTION
Notes:
- Breaks circular dependency with `useful`.
- Downgrades `validateur` so tests run green again
- Moves migration helpers into `domain` (they used to be in `useful`)
- Removes unnecessary dependency on `clojure.tools.logging` and `logback`
- Minimizes number of versions `tzbackend` needs to pull