### PR TITLE
Feature: Query restrictors

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.1.0"
+(defproject com.timezynk/domain "2.2.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -7,7 +7,7 @@
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
-                 [com.timezynk/useful "2.3.0"]
+                 [com.timezynk/useful "2.4.0"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -404,13 +404,16 @@
                     (let [dom-type-collection (if pre-process-dtc
                                                 (pre-process-dtc :index dom-type-collection req)
                                                 dom-type-collection)
-                          restriction         (pack/pack-query dom-type-collection req)
+                          dtc-name            (get-dtc-name dom-type-collection)
+                          restriction         (->> req
+                                                   (pack/pack-query dom-type-collection)
+                                                   (ability/downscope :index dtc-name))
                           collects            (pack/pack-collects dom-type-collection req)]
                       (-> (p/select dom-type-collection restriction collects)
                           (authorize-station (fn [dtc doc]
                                                (ability/authorize!
                                                 :index
-                                                (get-dtc-name dom-type-collection)
+                                                dtc-name
                                                 (get-in dtc [:collection :restriction]))
                                                doc))
                           (add-stations* index)

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -3,8 +3,8 @@
   :url "http://example.com/FIXME"
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[com.timezynk/domain "2.1.0"]
-                 [com.timezynk/useful "2.3.0" :scope "dev"]
+  :dependencies [[com.timezynk/domain "2.2.0"]
+                 [com.timezynk/useful "2.4.0" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain-types "1.0.5"
+(defproject com.timezynk/domain-types "1.0.6"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "BSD 3 Clause"

--- a/domain_types/src/com/timezynk/domain_types/breaks.clj
+++ b/domain_types/src/com/timezynk/domain_types/breaks.clj
@@ -17,9 +17,9 @@
   (if (and (:start doc) (:end doc))
     doc
     (let [vid (or (:vid doc) (-> dtc :collection :restriction :vid))]
-      (when vid
-        (->> (p/by-vid dtc vid)
-             (pack/pack-doc dtc))))))
+      (some->> vid
+               (p/by-vid dtc)
+               (pack/pack-doc dtc)))))
 
 (defn validate-breaks! [dtc doc]
   (let [{:keys [start end breaks]} (use-or-load dtc doc)]


### PR DESCRIPTION
Applies the query restriction `cancan` feature.

Notes:
- updates the `useful` library to version `2.4.0`
- applies the `downscope` function to the DTC restriction for `index` routes