### PR TITLE
Feature: Source authorization from dedicated library

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -7,7 +7,8 @@
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
-                 [com.timezynk/useful "2.4.0"]
+                 [com.timezynk/cancancan "0.1.0"]
+                 [com.timezynk/useful "2.5.0"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.2.0"
+(defproject com.timezynk/domain "2.2.1"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/core.clj
+++ b/domain/src/com/timezynk/domain/core.clj
@@ -10,7 +10,7 @@
    [com.timezynk.domain.schema :as s]
    [com.timezynk.domain.update-leafs :refer [update-leafs-via-directive]]
    [com.timezynk.domain.validation :as v]
-   [com.timezynk.useful.cancan :as ability]
+   [com.timezynk.cancancan.core :as ability]
    [com.timezynk.useful.date :as date]
    [com.timezynk.useful.rest :refer [json-response etag-response]]
    [compojure.core :refer [routes GET POST PUT PATCH DELETE]]

--- a/domain/src/com/timezynk/domain/mask/built_in.clj
+++ b/domain/src/com/timezynk/domain/mask/built_in.clj
@@ -1,6 +1,6 @@
 (ns com.timezynk.domain.mask.built-in
   "Useful functions for masking DTC properties."
-  (:require [com.timezynk.useful.cancan :as ability]
+  (:require [com.timezynk.cancancan.core :as ability]
             [com.timezynk.domain.core :as c]))
 
 (defn unauthorized?

--- a/domain/test/com/timezynk/domain/mask/built_in_test.clj
+++ b/domain/test/com/timezynk/domain/mask/built_in_test.clj
@@ -5,7 +5,7 @@
             [com.timezynk.domain.mask.built-in :refer [unauthorized?]]
             [com.timezynk.domain.schema :as s]
             [com.timezynk.domain.mongo.core :as m]
-            [com.timezynk.useful.cancan :as ability]
+            [com.timezynk.cancancan.core :as ability]
             [com.timezynk.domain.persistence :as p]
             [com.timezynk.domain.utils :as u])
   (:import [org.bson.types ObjectId]))


### PR DESCRIPTION
Authorization has been extracted from `useful` and gotten a repository of its own. Binaries are available on Clojars at `com.timezynk/cancancan`. This PR updates the affected subprojects accordingly.