### PR TITLE
Fix: Throttle mchan threads

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
                  [com.timezynk/cancancan "0.3.0"]
-                 [com.timezynk/useful "2.7.0"]
+                 [com.timezynk/useful "2.7.1"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
                  [com.timezynk/cancancan "0.3.0"]
-                 [com.timezynk/useful "2.7.1"]
+                 [com.timezynk/useful "2.7.2"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.2.7"
+(defproject com.timezynk/domain "2.2.8"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
                  [com.timezynk/cancancan "0.3.0"]
-                 [com.timezynk/useful "2.7.2"]
+                 [com.timezynk/useful "2.7.3"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[com.timezynk/domain "2.2.7"]
-                 [com.timezynk/useful "2.7.0" :scope "dev"]
+                 [com.timezynk/useful "2.7.1" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[com.timezynk/domain "2.2.8"]
-                 [com.timezynk/useful "2.7.1" :scope "dev"]
+                 [com.timezynk/useful "2.7.2" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/TimeZynk/domain/tree/master/domain_types"
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[com.timezynk/domain "2.2.7"]
+  :dependencies [[com.timezynk/domain "2.2.8"]
                  [com.timezynk/useful "2.7.1" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[com.timezynk/domain "2.2.8"]
-                 [com.timezynk/useful "2.7.2" :scope "dev"]
+                 [com.timezynk/useful "2.7.3" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain-types "1.0.12"
+(defproject com.timezynk/domain-types "1.0.13"
   :description "Modeling extras built on top of domain"
   :url "https://github.com/TimeZynk/domain/tree/master/domain_types"
   :license {:name "BSD 3 Clause"


### PR DESCRIPTION
`mchan` throttling has been introduced to `com.timezynk.useful` version `2.7.1`. Versions `2.7.2` and  `2.7.3` bring improvements.

This PR upgrades the dependency to `useful` to `2.7.3`.