### PR TITLE
Bugfix: Environment is determined at compile-time

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.3.2"
+(defproject com.timezynk/domain "2.3.3"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -7,9 +7,9 @@
         :url  "https://github.com/TimeZynk/domain"}
   :dependencies [[com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
-                 [com.timezynk/bus "1.2.3"]
+                 [com.timezynk/bus "1.2.4"]
                  [com.timezynk/cancancan "0.3.0"]
-                 [com.timezynk/useful "4.5.1"]
+                 [com.timezynk/useful "4.5.2"]
                  [compojure "1.7.0" :scope "provided" :exclusions [commons-codec]]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[com.timezynk/domain "2.3.2"]
-                 [com.timezynk/useful "4.5.1" :scope "dev"]
+                 [com.timezynk/useful "4.5.2" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [slingshot "0.12.2"]]

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -1,9 +1,9 @@
-(defproject com.timezynk/domain-types "1.0.17"
+(defproject com.timezynk/domain-types "1.0.18"
   :description "Modeling extras built on top of domain"
   :url "https://github.com/TimeZynk/domain/tree/master/domain_types"
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[com.timezynk/domain "2.3.2"]
+  :dependencies [[com.timezynk/domain "2.3.3"]
                  [com.timezynk/useful "4.5.2" :scope "dev"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]


### PR DESCRIPTION
Sources the relevant fix from upstream libraries:
- `useful`
- `bus`