### PR TITLE
Feature: Parameterize mchan queue

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -11,7 +11,7 @@
                  [ch.qos.logback.contrib/logback-json-classic "0.1.5" :scope "provided"]
                  [com.novemberain/validateur "1.2.0"]
                  [com.timezynk/assembly-line "1.0.1"]
-                 [com.timezynk/bus "1.2.7" :scope "provided"]
+                 [com.timezynk/bus "1.3.0" :scope "provided"]
                  [com.timezynk/cancancan "0.3.0" :scope "provided"]
                  [com.timezynk/domus "1.0.2" :scope "provided"]
                  [com.timezynk/useful "4.10.0" :scope "provided"]

--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.3.6"
+(defproject com.timezynk/domain "2.4.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -3,6 +3,7 @@
    [somnium.congomongo :as mongo]
    [com.timezynk.bus.core :as bus]
    [com.timezynk.bus.group :as cg]
+   [com.timezynk.useful.env :as env]
    [com.timezynk.domain.mongo.channel.context :as context]
    [com.timezynk.domain.mongo.channel.hook :refer [->PerformanceTrackingHook]]))
 
@@ -12,7 +13,8 @@
 
 (def ^:const NUM_BROADCAST_WORKERS 2)
 
-(def ^:const NUM_PERSISTED_WORKERS 2)
+(def NUM_PERSISTED_WORKERS
+  (env/parse-int-var "BACKGROUND_JOB_QUEUE_NUM_WORKERS" 2))
 
 (defonce request-response (atom nil))
 

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -16,6 +16,12 @@
 (def NUM_PERSISTED_WORKERS
   (env/parse-int-var "BACKGROUND_JOB_QUEUE_NUM_WORKERS" 2))
 
+(def MIN_PERSISTED_INTERVAL
+  (env/parse-int-var "BACKGROUND_JOB_QUEUE_MINIMUM_INTERVAL"))
+
+(def MIN_PERSISTED_SLEEP
+  (env/parse-int-var "BACKGROUND_JOB_QUEUE_MINIMUM_SLEEP"))
+
 (defonce request-response (atom nil))
 
 (defonce broadcast (atom nil))
@@ -86,8 +92,8 @@
                 (bus/initialize NUM_PERSISTED_WORKERS
                                 {:queue-id :mchan_jobs
                                  :queue-collection :mchan.queue
-                                 :min-interval (System/getenv "BACKGROUND_JOB_QUEUE_MINIMUM_INTERVAL")
-                                 :min-sleep (System/getenv "BACKGROUND_JOB_QUEUE_MINIMUM_SLEEP")})))))
+                                 :min-interval MIN_PERSISTED_INTERVAL
+                                 :min-sleep MIN_PERSISTED_SLEEP})))))
 
 (defn destroy []
   (when @request-response

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -83,7 +83,9 @@
             (-> (bus/create cg/PERSISTED)
                 (bus/initialize NUM_PERSISTED_WORKERS
                                 {:queue-id :mchan_jobs
-                                 :queue-collection :mchan.queue})))))
+                                 :queue-collection :mchan.queue
+                                 :min-interval (System/getenv "BACKGROUND_JOB_QUEUE_MINIMUM_INTERVAL")
+                                 :min-sleep (System/getenv "BACKGROUND_JOB_QUEUE_MINIMUM_SLEEP")})))))
 
 (defn destroy []
   (when @request-response


### PR DESCRIPTION
Notes:

- sources `bus 1.3.0` to get the parameterization feature for the `PERSISTED` variant
- paramaterizes the persisted bus with values read out of the process environment:
  - `BACKGROUND_JOB_QUEUE_NUM_WORKERS`
  - `BACKGROUND_JOB_QUEUE_MINIMUM_INTERVAL`
  - `BACKGROUND_JOB_QUEUE_MINIMUM_SLEEP`