### PR TITLE
Feature: Parameterize persisted bus worker priority

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.4.0"
+(defproject com.timezynk/domain "2.5.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -16,6 +16,9 @@
 (def NUM_PERSISTED_WORKERS
   (env/parse-int-var "BACKGROUND_JOB_QUEUE_NUM_WORKERS" 2))
 
+(def PERSISTED_THREAD_PRIORITY
+  (env/parse-int-var "BACKGROUND_JOB_QUEUE_WORKER_PRIORITY"))
+
 (def MIN_PERSISTED_INTERVAL
   (env/parse-int-var "BACKGROUND_JOB_QUEUE_MINIMUM_INTERVAL"))
 
@@ -92,6 +95,7 @@
                 (bus/initialize NUM_PERSISTED_WORKERS
                                 {:queue-id :mchan_jobs
                                  :queue-collection :mchan.queue
+                                 :thread-priority PERSISTED_THREAD_PRIORITY
                                  :min-interval MIN_PERSISTED_INTERVAL
                                  :min-sleep MIN_PERSISTED_SLEEP})))))
 


### PR DESCRIPTION
Notes:
- reads environment variable `BACKGROUND_JOB_QUEUE_WORKER_PRIORITY`
- attempts to parse int, will leave `nil` otherwise (effectively applying `Thread/MIN_PRIORITY`)