### PR TITLE
Bugfix: Emits update even when document is clean

### DIFF
--- a/domain/project.clj
+++ b/domain/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain "2.5.0"
+(defproject com.timezynk/domain "2.6.0"
   :description "Database modeling library for Clojure and MongoDB"
   :url "https://github.com/TimeZynk/domain/tree/master/domain"
   :license {:name "BSD 3 Clause"

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -37,7 +37,7 @@
     :created :valid-from :valid-to})
 
 (defn- significant
-  "Strips `doc` of extra-domain fields."
+  "Strips `doc` of non-domain fields."
   [doc]
   (apply dissoc doc NON_DOMAIN_FIELDS))
 

--- a/domain/src/com/timezynk/domain/mongo/channel.clj
+++ b/domain/src/com/timezynk/domain/mongo/channel.clj
@@ -31,10 +31,15 @@
 
 (defonce persisted (atom nil))
 
+(def ^:private ^:const NON_DOMAIN_FIELDS
+  #{:id :vid :pid :lock-id
+    :created-by :changed-by
+    :created :valid-from :valid-to})
+
 (defn- significant
   "Strips `doc` of extra-domain fields."
   [doc]
-  (dissoc doc :lock-id :changed-by :valid-from))
+  (apply dissoc doc NON_DOMAIN_FIELDS))
 
 (defn- changed?
   "True if the document pair represents domain-level change, false otherwise."

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/domain-types "1.0.20"
+(defproject com.timezynk/domain-types "1.1.0"
   :description "Modeling extras built on top of domain"
   :url "https://github.com/TimeZynk/domain/tree/master/domain_types"
   :license {:name "BSD 3 Clause"

--- a/domain_types/project.clj
+++ b/domain_types/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/TimeZynk/domain/tree/master/domain_types"
   :license {:name "BSD 3 Clause"
             :url "https://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[com.timezynk/domain "2.3.6" :scope "provided"]
+  :dependencies [[com.timezynk/domain "2.6.0" :scope "provided"]
                  [com.timezynk/useful "4.10.0" :scope "provided"]
                  [congomongo "2.6.0" :scope "provided"]
                  [org.clojure/clojure "1.11.1" :scope "provided"]


### PR DESCRIPTION
Notes:
- puts message on `bus` conditionally
- documents on the `:update` topic are inspected
- scrutiny is performed for domain-level change:
  - **not** document meta
  - **not** version info
  - **not** concurrency artifacts